### PR TITLE
React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0"
+    "react": "^15.1.0 || ^16.0.0",
+    "react-dom": "^15.1.0 || ^16.0.0"
   },
   "dependencies": {
     "create-react-class": "^15.6.3"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "react-dom": "^15.1.0 || ^16.0.0"
   },
   "dependencies": {
-    "create-react-class": "^15.6.3"
+    "create-react-class": "^15.6.3",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "http-server": "^0.7.4",
-    "prop-types": "^15.7.2",
     "watchify": "^2.2.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-input-datalist",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "HTML5 input/datalist combination component",
   "main": "react-input-datalist.js",
   "author": {
@@ -14,11 +14,15 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.1.0"
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0"
+  },
+  "dependencies": {
+    "create-react-class": "^15.6.3"
   },
   "devDependencies": {
     "http-server": "^0.7.4",
-    "react-dom": "^15.1.0",
+    "prop-types": "^15.7.2",
     "watchify": "^2.2.1"
   },
   "keywords": [

--- a/react-input-datalist.js
+++ b/react-input-datalist.js
@@ -1,20 +1,22 @@
 var React = require('react');
-var D = React.DOM;
+var D = require('react-dom');
+var PropTypes = require('prop-types');
+var createClass = require('create-react-class');
 
 var DEFAULT_HIGHLIGHTED_INDEX = -1;
 var NO_RESULTS = [];
 
-module.exports = React.createClass({
+module.exports = createClass({
     propTypes: {
-        onChange: React.PropTypes.func.isRequired,
-        value: React.PropTypes.string.isRequired,
-        datalist: React.PropTypes.array,
-        onEnter: React.PropTypes.func,
-        className: React.PropTypes.string,
-        inputClassName: React.PropTypes.string,
-        minLength: React.PropTypes.number,
-        maxOptions: React.PropTypes.number,
-        predicate: React.PropTypes.func
+        onChange: PropTypes.func.isRequired,
+        value: PropTypes.string.isRequired,
+        datalist: PropTypes.array,
+        onEnter: PropTypes.func,
+        className: PropTypes.string,
+        inputClassName: PropTypes.string,
+        minLength: PropTypes.number,
+        maxOptions: PropTypes.number,
+        predicate: PropTypes.func
     },
     getInitialState: getInitialState,
     getDefaultProps: function() {


### PR DESCRIPTION
This PR contains the tweaks I made to get this component working with React 16.
Thought if others are still relying on this component they could use the support.

- Uses `create-react-class` to implement the legacy class.
- Imports `prop-types` and `react-dom` rather than relying on React to provide it.

I've bumped the major version.